### PR TITLE
Alternate fun facts and jokes

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
     </div>
 
     <div class="fun-fact-container">
-      <div class="fun-title">Fun Fact:</div>
+      <div class="fun-title" id="funTitle">Fun Fact:</div>
       <div class="fun-fact" id="funFact">Loading fun fact…</div>
     </div>
   </div>
@@ -110,11 +110,16 @@ function ring(){const n=new Date(),nx=new Date(n);nx.setHours(n.getHours()+1,0,0
   pie.style.background=`conic-gradient(var(--accent-color) ${(d/36e5)*360}deg,transparent 0deg)`;}
 ring();setInterval(ring,250);
 
-/* ----- Fun facts every 10 min ----- */
-let facts=[];
-fetch('facts.json').then(r=>r.ok?r.json():[]).then(j=>{facts=j;fact();setInterval(fact,600000)});
-function fact(){if(!facts.length)return;const hc=Math.floor((Date.now()+new Date().getTimezoneOffset()*60000)/36e5);
-  document.getElementById('funFact').textContent=facts[xfnv1a('f'+hc)%facts.length];}
+/* ----- Fun facts / Jokes every 10 min ----- */
+let facts=[],jokes=[];
+function initText(){if(facts.length&&jokes.length){updateText();setInterval(updateText,600000);}}
+fetch('facts.json').then(r=>r.ok?r.json():[]).then(j=>{facts=j;initText();});
+fetch('jokes.json').then(r=>r.ok?r.json():[]).then(j=>{jokes=j;initText();});
+function updateText(){const cycle=Math.floor((Date.now()+new Date().getTimezoneOffset()*60000)/600000);
+  const title=document.getElementById('funTitle');
+  const box=document.getElementById('funFact');
+  if(cycle%2===0){title.textContent='Fun Fact:';box.textContent=facts[xfnv1a('f'+cycle)%facts.length];}
+  else{title.textContent='Joke:';box.textContent=jokes[xfnv1a('j'+cycle)%jokes.length];}}
 
 /* ----- Hover preview (unchanged) ----- */
 let tip=null;


### PR DESCRIPTION
## Summary
- show the fun/joke title element as `funTitle`
- fetch `jokes.json` and rotate between jokes and facts every 10 minutes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853a3d2f9b48326aab6cb6c51bc31e2