### PR TITLE
Fix JSON syntax errors

### DIFF
--- a/jokes.json
+++ b/jokes.json
@@ -90,7 +90,7 @@
   "Why did the cookie cry? Because his mother was a wafer so long.",
   "Why did the man run around his bed? Because he was trying to catch up on his sleep.",
   "What do you call a deer with no eyes? No idea.",
-  "I couldn’t figure out how to fasten my seatbelt. Then it clicked."
+  "I couldn’t figure out how to fasten my seatbelt. Then it clicked.",
   "I told my pet rock I loved her, but she just sat there stone-faced.",
   "Why did the magnet get arrested? It had too much attraction.",
   "My friend’s bakery burned down last night. Now his business is toast.",
@@ -164,7 +164,7 @@
   "I built a treehouse — it’s branching out my real estate portfolio.",
   "I got into meditation — it’s mind over mattress.",
   "I became a locksmith — now I’m key to success.",
-  "I tried dog training — but it was a ruff job."
+  "I tried dog training — but it was a ruff job.",
    "I started a company recycling batteries—it's a current business.",
   "My stapler broke; I'm now at loose ends.",
   "I took a poll on ladders—results were up and down.",
@@ -288,8 +288,7 @@
   "Plateaus are the highest form of flattery.",
   "Corduroy pillows are making headlines.",
   "Bakers trade secrets—they’re on a knead-to-know basis.",
-  "A boiled egg is hard to beat."
-  [
+  "A boiled egg is hard to beat.",
   "I once ate a dictionary—now I have thesaurus throat.",
   "Why did the smartphone go to art school? It wanted to improve its selfies.",
   "Sailors don’t like math—too many pi-rates.",


### PR DESCRIPTION
## Summary
- correct invalid JSON syntax in jokes.json

## Testing
- `node -e "const fs=require('fs');JSON.parse(fs.readFileSync('jokes.json','utf8'));JSON.parse(fs.readFileSync('facts.json','utf8'));console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_6853ba7cbb70832690592481db5fcb56