### PR TITLE
Show video after countdown completes

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
     .pie-timer{width:18px;height:18px;border-radius:50%;transform:scaleX(-1);background:conic-gradient(var(--accent-color)360deg,transparent 0deg)}
     .image-countdown{font-size:.65rem;color:rgba(255,255,255,.8);text-shadow:0 0 4px rgba(0,0,0,.3)}
 
+    #finalVideo{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;display:none}
+
     #toggleView{position:absolute;bottom:10px;left:10px;background:rgba(0,0,0,.6);color:#fff;border:none;
                 padding:.5rem .75rem;font-family:var(--font-family);font-size:.75rem;border-radius:4px;cursor:pointer;opacity:.8}
     #toggleView:hover{opacity:1}
@@ -40,6 +42,7 @@
 <body>
 
   <div class="background" id="background"></div>
+  <video id="finalVideo" src="images/final.mp4" loop muted autoplay playsinline></video>
 
   <div class="overlay">
     <div class="timer" role="timer" aria-live="polite">
@@ -66,8 +69,19 @@
 <script>
 /* ----- Countdown ----- */
 const target=Date.parse("2025-08-15T17:30:00");
+let ended=false;
 function anim(id,v){const e=document.getElementById(id);if(e.textContent!==v){e.textContent=v;e.classList.add('animate');setTimeout(()=>e.classList.remove('animate'),300);}}
-function clock(){const d=target-Date.now();if(d<=0)return;
+function endCountdown(){
+  if(ended)return;
+  ended=true;
+  document.getElementById('background').style.display='none';
+  document.querySelector('.overlay').style.display='none';
+  document.querySelector('.image-countdown-wrapper').style.display='none';
+  document.getElementById('toggleView').style.display='none';
+  const vid=document.getElementById('finalVideo');
+  if(vid){vid.style.display='block';vid.play();}
+}
+function clock(){const d=target-Date.now();if(d<=0){endCountdown();return;}
   const hrs=Math.floor((d%864e5)/36e5);
   if(document.body.classList.contains('simple')){
     anim('days',String(Math.floor(d/864e5)).padStart(2,'0'));anim('hours',String(hrs).padStart(2,'0'));anim('months','');


### PR DESCRIPTION
## Summary
- add final video element and style
- hide countdown elements when timer hits zero and play video on loop

## Testing
- `ls -lh images/final.mp4`


------
https://chatgpt.com/codex/tasks/task_e_685cf37f39488326a30bb369197f0597